### PR TITLE
RMRPA-26 Release-Version on a release-branch is asking for ancestor

### DIFF
--- a/Core.IntegrationTests/Git/CommandLineGitClientTests.cs
+++ b/Core.IntegrationTests/Git/CommandLineGitClientTests.cs
@@ -180,9 +180,7 @@ internal class CommandLineGitClientTests : GitBackedTestBase
 
     var ancestor = client.GetAncestors("develop");
 
-    Assert.That(ancestor, Does.Contain("develop"));
-    Assert.That(ancestor, Does.Not.Contain("master"));
-    Assert.That(ancestor, Does.Not.Contain("release/v1.0.1"));
+    Assert.That(ancestor, Is.EquivalentTo(new []{"develop"}));
   }
 
   [Test]
@@ -202,9 +200,26 @@ internal class CommandLineGitClientTests : GitBackedTestBase
 
     var ancestor = client.GetAncestors("develop", "release");
 
-    Assert.That(ancestor, Does.Contain("develop"));
-    Assert.That(ancestor, Does.Contain("release/v1.0.1"));
-    Assert.That(ancestor, Does.Not.Contain("master"));
+    Assert.That(ancestor, Is.EquivalentTo(new []{"develop", "release/v1.0.1"}));
+  }
+
+  [Test]
+  public void GetAncestors_WithFeatureBranchWithAncestorNameInTitle_DoesNotReturnFeatureBranch()
+  {
+    AddCommit();
+    ExecuteGitCommand("checkout -b develop");
+    AddCommit();
+    ExecuteGitCommand("checkout develop");
+    AddCommit();
+    ExecuteGitCommand("checkout -b feature/something-needs-to-be-developed");
+    AddCommit();
+    ExecuteGitCommand("checkout master");
+
+    var client = new CommandLineGitClient();
+
+    var ancestor = client.GetAncestors("develop");
+
+    Assert.That(ancestor, Is.EquivalentTo(new []{"develop"}));
   }
 
   [Test]
@@ -218,9 +233,7 @@ internal class CommandLineGitClientTests : GitBackedTestBase
 
     var ancestor = client.GetAncestors("develop");
 
-    Assert.That(ancestor, Does.Contain("develop"));
-    Assert.That(ancestor, Does.Contain("developer"));
-    Assert.That(ancestor, Does.Not.Contain("release/v1.0.1"));
+    Assert.That(ancestor, Is.EquivalentTo(new []{"develop", "developer"}));
   }
 
   [Test]
@@ -240,8 +253,7 @@ internal class CommandLineGitClientTests : GitBackedTestBase
 
     var ancestor = client.GetAncestors("develop");
 
-    Assert.That(ancestor, Does.Contain("developer"));
-    Assert.That(ancestor, Does.Contain("developeria"));
+    Assert.That(ancestor, Is.EquivalentTo(new []{"developeria", "developer", "develop"}));
   }
 
   [Test]

--- a/Core/Git/AncestorFinder.cs
+++ b/Core/Git/AncestorFinder.cs
@@ -63,7 +63,9 @@ public class AncestorFinder
     }
 
     _log.Warning("Multiple matching ancestors were found: '{FoundAncestors}'", foundAncestors);
-    var input = _inputReader.ReadStringChoice("Please enter the name of the ancestor branch:", foundAncestors);
+    var input = _inputReader.ReadStringChoice(
+        "Found multiple branches that could be the ancestor branch.\nPlease choose the correct ancestor branch (used to determine which versions are available and which branch to merge into):",
+        foundAncestors);
     _log.Debug("User input for the name of the ancestor branch was read: '{UserInput}'", input);
     return input;
   }

--- a/Core/Git/CommandLineGitClient.cs
+++ b/Core/Git/CommandLineGitClient.cs
@@ -151,7 +151,7 @@ public class CommandLineGitClient : IGitClient
 
     foreach (var ancestor in selectAncestors)
     foreach (var expected in expectedAncestor)
-      if (expected.Contains(ancestor) || ancestor.Contains(expected))
+      if (expected.StartsWith(ancestor) || ancestor.StartsWith(expected))
         foundAncestors.Add(ancestor);
 
     return foundAncestors;


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RMRPA-26

Looking for the ancestor is correct, as we need it to decide what to do. 
The message might have been misleading and not really telling users why/what. 

Also there was an obvious bug showing a non develop branch when only looking for develop branches -> should be fixed now